### PR TITLE
welcome: send message when service message not found

### DIFF
--- a/tg_bot/modules/welcome.py
+++ b/tg_bot/modules/welcome.py
@@ -93,6 +93,7 @@ def send(update, message, keyboard, backup_message):
             parse_mode=ParseMode.MARKDOWN,
             reply_markup=keyboard,
             reply_to_message_id=reply,
+            allow_sending_without_reply=True,
         )
     except BadRequest as excp:
         if excp.message == 'Button_url_invalid':
@@ -395,6 +396,7 @@ def new_member(update: Update, context: CallbackContext):  # sourcery no-metrics
                     ),
                     parse_mode=ParseMode.MARKDOWN,
                     reply_to_message_id=reply,
+                    allow_sending_without_reply=True,
                 )
                 bot.restrict_chat_member(
                     chat.id,
@@ -486,6 +488,7 @@ def new_member(update: Update, context: CallbackContext):  # sourcery no-metrics
                                           reply_markup=InlineKeyboardMarkup(btn),
                                           parse_mode=ParseMode.MARKDOWN,
                                           reply_to_message_id=reply,
+                                          allow_sending_without_reply=True,
                                           )
                 bot.restrict_chat_member(
                     chat.id,


### PR DESCRIPTION
If we set up two or more bots in a group for cleaning service messages, the bot cannot greet users if their joining or left message was previously deleted by other bots.