### PR TITLE
Webhooks fixes and more

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ currencyconverter
 emoji
 feedparser
 future
-git+https://github.com/python-telegram-bot/ptbcontrib.git
 gitpython
 gpytranslate
 markdown2
@@ -18,7 +17,7 @@ psutil
 psycopg2-binary
 pyYAML>=5.1.2
 pyrate-limiter
-python-telegram-bot==13.11
+python-telegram-bot==13.15
 requests
 spamwatch
 speedtest-cli

--- a/tg_bot/__init__.py
+++ b/tg_bot/__init__.py
@@ -8,7 +8,6 @@ import telegram.ext as tg
 from telethon import TelegramClient
 from telethon.sessions import MemorySession
 from configparser import ConfigParser
-from ptbcontrib.postgres_persistence import PostgresPersistence
 from logging.config import fileConfig
 
 StartTime = time.time()
@@ -139,14 +138,9 @@ CF_API_KEY = KInit.CF_API_KEY
 # SpamWatch
 sw = KInit.init_sw()
 
-from tg_bot.modules.sql import SESSION
 
-if not KInit.DROP_UPDATES:
-    updater = tg.Updater(token=TOKEN, base_url=KInit.BOT_API_URL, base_file_url=KInit.BOT_API_FILE_URL, workers=min(32, os.cpu_count() + 4), request_kwargs={"read_timeout": 10, "connect_timeout": 10}, persistence=PostgresPersistence(session=SESSION))
-    
-else:
-    updater = tg.Updater(token=TOKEN, base_url=KInit.BOT_API_URL, base_file_url=KInit.BOT_API_FILE_URL, workers=min(32, os.cpu_count() + 4), request_kwargs={"read_timeout": 10, "connect_timeout": 10})
-    
+updater = tg.Updater(token=TOKEN, base_url=KInit.BOT_API_URL, base_file_url=KInit.BOT_API_FILE_URL, workers=min(32, os.cpu_count() + 4), request_kwargs={"read_timeout": 10, "connect_timeout": 10})
+
 telethn = TelegramClient(MemorySession(), APP_ID, API_HASH)
 dispatcher = updater.dispatcher
 

--- a/tg_bot/__main__.py
+++ b/tg_bot/__main__.py
@@ -707,12 +707,10 @@ def main():
 
     if WEBHOOK:
         log.info("Using webhooks.")
-        updater.start_webhook(listen="127.0.0.1", port=PORT, url_path=TOKEN)
-
-        if CERT_PATH:
-            updater.bot.set_webhook(url=URL + TOKEN, certificate=open(CERT_PATH, "rb"))
-        else:
-            updater.bot.set_webhook(url=URL + TOKEN)
+        updater.start_webhook(listen="0.0.0.0", port=PORT, url_path=TOKEN, allowed_updates=Update.ALL_TYPES, 
+                            webhook_url=URL+TOKEN, drop_pending_updates=KInit.DROP_UPDATES, 
+                            cert=CERT_PATH if CERT_PATH else None)
+        log.info(f"Kigyo started, Using webhooks. | BOT: [@{dispatcher.bot.username}]")
 
     else:
         log.info(f"Kigyo started, Using long polling. | BOT: [@{dispatcher.bot.username}]")
@@ -721,10 +719,7 @@ def main():
         KigyoINIT.bot_name = dispatcher.bot.first_name
         updater.start_polling(timeout=15, read_latency=4, allowed_updates=Update.ALL_TYPES,
                               drop_pending_updates=KInit.DROP_UPDATES)
-    if len(argv) not in (1, 3, 4):
-        telethn.disconnect()
-    else:
-        telethn.run_until_disconnected()
+    telethn.run_until_disconnected()
     updater.idle()
 
 

--- a/tg_bot/modules/connection.py
+++ b/tg_bot/modules/connection.py
@@ -389,7 +389,7 @@ from tg_bot.modules.language import gs
 def get_help(chat):
     return gs(chat, "connections_help")
 
-CONNECT_CHAT_HANDLER = CommandHandler("connect", connect_chat, pass_args=True)
+CONNECT_CHAT_HANDLER = CommandHandler("connect", connect_chat, pass_args=True, run_async=True)
 CONNECTION_CHAT_HANDLER = CommandHandler("connection", connection_chat, run_async=True)
 DISCONNECT_CHAT_HANDLER = CommandHandler("disconnect", disconnect_chat, run_async=True)
 ALLOW_CONNECTIONS_HANDLER = CommandHandler(

--- a/tg_bot/modules/disable.py
+++ b/tg_bot/modules/disable.py
@@ -270,16 +270,16 @@ It'll also allow you to autodelete them, stopping people from bluetexting.
     """
 
     DISABLE_HANDLER = CommandHandler(
-        "disable", disable, pass_args=True
+        "disable", disable, pass_args=True, run_async=True
     )  # , filters=Filters.chat_type.groups)
     ENABLE_HANDLER = CommandHandler(
-        "enable", enable, pass_args=True
+        "enable", enable, pass_args=True, run_async=True
     )  # , filters=Filters.chat_type.groups)
     COMMANDS_HANDLER = CommandHandler(
-        ["cmds", "disabled"], commands
+        ["cmds", "disabled"], commands, run_async=True
     )  # , filters=Filters.chat_type.groups)
     TOGGLE_HANDLER = CommandHandler(
-        "listcmds", list_cmds
+        "listcmds", list_cmds, run_async=True
     )  # , filters=Filters.chat_type.groups)
 
     dispatcher.add_handler(DISABLE_HANDLER)

--- a/tg_bot/modules/sticker_blacklist.py
+++ b/tg_bot/modules/sticker_blacklist.py
@@ -507,17 +507,17 @@ def get_help(chat):
 
 
 BLACKLIST_STICKER_HANDLER = DisableAbleCommandHandler(
-    "blsticker", blackliststicker, admin_ok=True,
+    "blsticker", blackliststicker, admin_ok=True, run_async=True
 )
 ADDBLACKLIST_STICKER_HANDLER = DisableAbleCommandHandler(
-    "addblsticker", add_blackliststicker,
+    "addblsticker", add_blackliststicker, run_async=True
 )
 UNBLACKLIST_STICKER_HANDLER = CommandHandler(
-    ["unblsticker", "rmblsticker"], unblackliststicker,
+    ["unblsticker", "rmblsticker"], unblackliststicker, run_async=True
 )
-BLACKLISTMODE_HANDLER = CommandHandler("blstickermode", blacklist_mode)
+BLACKLISTMODE_HANDLER = CommandHandler("blstickermode", blacklist_mode, run_async=True)
 BLACKLIST_STICKER_DEL_HANDLER = MessageHandler(
-    Filters.sticker & Filters.chat_type.groups, del_blackliststicker,
+    Filters.sticker & Filters.chat_type.groups, del_blackliststicker, run_async=True
 )
 
 dispatcher.add_handler(BLACKLIST_STICKER_HANDLER)


### PR DESCRIPTION
- bump ptb to 13.15
- remove postgres persistence as it's not used and has an impact on the bot performance
- fix starting the bot using webhooks and remove `updater.bot.set_webhook()` as the `updater.start_webhook()` method calls `set_webhook()` in the new ptb versions
- added run_async as True to handlers that were missing it