### PR TITLE
Limited pyrate-limiter upto 3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pillow>=4.2.0
 psutil
 psycopg2-binary
 pyYAML>=5.1.2
-pyrate-limiter
+pyrate-limiter<3.0
 python-telegram-bot==13.15
 requests
 spamwatch


### PR DESCRIPTION
Fixed "Cannot Import Name 'RequestRate' from 'pyrate_limiter' "
Also Compatible with python 3.7